### PR TITLE
Correctly use protected_branches API

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -15,10 +15,10 @@ default_group = "ExampleGroup"
 [rules]
     [[rules.protected-branches]]
     name = "master"
-    push_access_levels = [{access_level = 40, access_level_description = "Masters"}]
-    merge_access_levels = [{access_level = 30, access_level_description = "Developers + Masters"}]
+    push_access_level = 40 # Masters
+    merge_access_level = 30 # Developers + Masters
 
     [[rules.protected-branches]]
     name = "deploy"
-    push_access_levels = [{access_level = 0, access_level_description = "No one"}]
-    merge_access_levels = [{access_level = 40, access_level_description = "Masters"}]
+    push_access_level = 0 # No one
+    merge_access_level = 40 # Masters

--- a/gitlab_admin/gitlab_admin.py
+++ b/gitlab_admin/gitlab_admin.py
@@ -39,16 +39,23 @@ def apply_protected_branches(project, protected_branches, dry_run):
         else:
             debug("protected branch exists: {}".format(branch))
             attributes = branch.attributes
-            if attributes['merge_access_levels'] == protected_branch['merge_access_levels'] and \
-               attributes['push_access_levels'] == protected_branch['push_access_levels']:
+            if (len(attributes['merge_access_levels']) == 1 and
+                    attributes['merge_access_levels'][0]['access_level'] == protected_branch['merge_access_level'] and
+                    len(attributes['push_access_levels']) == 1 and
+                    attributes['push_access_levels'][0]['access_level'] == protected_branch['push_access_level']):
+                debug("settings are equal")
                 continue
             if not dry_run:
                 # need to remove first to change settings
+                info("Remove branch protection for {}".format(protected_branch['name']))
                 project.protectedbranches.delete(protected_branch['name'])
-        if dry_run:
-            print("{}: would protect branch: {}".format(project.path_with_namespace, protected_branch['name']))
-        else:
-            project.protectedbranches.create(protected_branch)
+        print("{}: change: protect branch: {}".format(project.path_with_namespace, protected_branch['name']))
+        debug("{}".format(protected_branch))
+        if not dry_run:
+            project.protectedbranches.create(
+                    {'name': protected_branch['name']},
+                    push_access_level=protected_branch['push_access_level'],
+                    merge_access_level=protected_branch['merge_access_level'])
 
 
 def apply_rules(project, config, dry_run=True):


### PR DESCRIPTION
As implemented previously, the API call always set access levels to 40
(the default), since the other parameters weren't passed correctly and
thus ignored.

Sadly it's not yet possible to configure multiple access levels for
different groups and users, see:

 * https://gitlab.com/gitlab-org/gitlab-ee/issues/1075
 * https://gitlab.com/gitlab-org/gitlab-ce/issues/35867